### PR TITLE
ec2: add `mbps` field to `Volume`

### DIFF
--- a/botocore/data/ec2/2016-11-15/service-2.json
+++ b/botocore/data/ec2/2016-11-15/service-2.json
@@ -42883,6 +42883,11 @@
           "documentation":"<p>The number of I/O operations per second (IOPS). For <code>gp3</code>, <code>io1</code>, and <code>io2</code> volumes, this represents the number of IOPS that are provisioned for the volume. For <code>gp2</code> volumes, this represents the baseline performance of the volume and the rate at which the volume accumulates I/O credits for bursting.</p>",
           "locationName":"iops"
         },
+        "Mbps": {
+          "shape":"Integer",
+          "documentation": "<p>Rate of data transfer.</p>",
+          "locationName": "mbps"
+        },
         "Tags":{
           "shape":"TagList",
           "documentation":"<p>Any tags assigned to the volume.</p>",


### PR DESCRIPTION
Support `mbps` field for `Volume` datatype